### PR TITLE
Convert tempfile_suffix into mapping

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -37,7 +37,10 @@ class Sass(NodeLinter):
     regex_error = re.compile(
         r'^(\w*)Error: (?P<msg>.*)'
     )
-    tempfile_suffix = 'scss'
+    tempfile_suffix = {
+        'scss': 'scss',
+        'sass': 'sass'
+    }
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 1.2.0'


### PR DESCRIPTION
`sass-lint` gets confused if it's told to lint a sass file with a `.scss` extension.
