### PR TITLE
Tempfile issue

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -37,10 +37,7 @@ class Sass(NodeLinter):
     regex_error = re.compile(
         r'^(\w*)Error: (?P<msg>.*)'
     )
-    tempfile_suffix = {
-        'scss': 'scss',
-        'sass': 'sass'
-    }
+    tempfile_suffix = '-'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 1.2.0'


### PR DESCRIPTION
When linting a `*.scss` file, the tempfile is created with a `*.sass` extension, leading to the following error:

``` sh
  1:1  error  Please check validity of the block starting from line #1  Fatal
```

I can confirm that this PR fixes this for `*.scss` but didn't have the time to check if it works for `*.css` and `*.sass` files (I guess it should).
Thats the recommended setting for file only linters (like csslint), refer http://www.sublimelinter.com/en/latest/linter_attributes.html#tempfile-suffix
