### PR TITLE
Fixed detection of .sass-lint.yml in home directory

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Sass(NodeLinter):
     """Provides an interface to the sass-lint executable."""
 
     cmd = ('sass-lint', '--verbose', '--no-exit', '--format', 'stylish')
-    config_file = ('--config', '.sass-lint.yml')
+    config_file = ('--config', '.sass-lint.yml', '~')
     npm_name = 'sass-lint'
     syntax = ('css', 'sass', 'scss')
     regex = (


### PR DESCRIPTION
The .sass-lint.yml in the home directory wasn't reconized.

I've change the line according to other linter plugins:
https://github.com/SublimeLinter/SublimeLinter-jshint/blob/master/linter.py#L49
https://github.com/SublimeLinter/SublimeLinter-coffeelint/blob/master/linter.py#L34
