### PR TITLE
Add scss scope

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -39,7 +39,7 @@ class Sass(NodeLinter):
         'sass': 'sass'
     }
     defaults = {
-        'selector': 'source.sass'
+        'selector': 'source.sass, source.scss'
     }
 
     def find_errors(self, output):


### PR DESCRIPTION
Adds back support for scss syntax by including the `source.scss` scope in the 'selector' attribute.